### PR TITLE
[DEVHUB-1411] Support Markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "next": "12.2.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-markdown": "8.0.3",
+    "remark-directive": "2.0.1",
     "theme-ui": "0.14.5"
   },
   "devDependencies": {

--- a/src/components/course-body/course-body.tsx
+++ b/src/components/course-body/course-body.tsx
@@ -1,3 +1,4 @@
+import Markdown from 'components/markdown';
 import CourseBodyProps from './types';
 import styles from './styles';
 
@@ -6,9 +7,24 @@ import styles from './styles';
   revist this once getting an idea of data structure
 */
 
+const markdownText = `## Course Outline
+
+This course is designed to cover a broad spectrum of topics on MongoDB and non-relational databases geared towards learners from beginner to advanced levels. The course includes lessons on comparing and contrasting relational and non-relational databases, outlining the architecture of MongoDB, and detailing how to model data in a document-oriented database. 
+
+This material can support a wide variety of instructional objectives, including learning best practices for querying data and structuring data models in MongoDB, and using features like transactions and aggregations.
+
+::youtube[Test]{#testeoiwejoewfij}
+
+## Course Format
+
+The course is organized into 22 lessons beginning with basic concepts and building on complexity as you go. Educators can teach the lessons in order as a full curriculum or pick and choose individual lessons based on the needs of the class. The lessons are formatted on slide decks with detailed instructor notes. There are also corresponding PDF versions available to download. Each lesson can be used as lectures during the semester, for ascrynous learning, and or/ as complementary material to a MongoDB University course. 
+
+Many of the lessons include hands-on exercises utilizing the [MongoDB Web Shell](https://mws.mongodb.com/) or mongosh to increase student engagement and give real world practice. The slides contain instructions on how to launch and connect to the shell. 
+
+Quiz questions and answers on key concepts are embedded throughout the lessons to enhance knowledge retention. 
+`;
+
 export default function CourseBody({
-  outlineText,
-  formatText,
   wrapperStyles,
 }: CourseBodyProps): JSX.Element {
   return (
@@ -18,22 +34,7 @@ export default function CourseBody({
         ...wrapperStyles,
       }}
     >
-      <section sx={styles.CourseBodySection}>
-        <h2 sx={styles.CourseBodyTitles}>Course Outline</h2>
-        {outlineText.map(text => (
-          <p key={text} sx={styles.CourseBodyText}>
-            {text}
-          </p>
-        ))}
-      </section>
-      <section>
-        <h2 sx={styles.CourseBodyTitles}>Course Format</h2>
-        {formatText.map(text => (
-          <p key={text} sx={styles.CourseBodyText}>
-            {text}
-          </p>
-        ))}
-      </section>
+      <Markdown text={markdownText} />
     </section>
   );
 }

--- a/src/components/course-body/course-body.tsx
+++ b/src/components/course-body/course-body.tsx
@@ -2,11 +2,6 @@ import Markdown from 'components/markdown';
 import CourseBodyProps from './types';
 import styles from './styles';
 
-/* 
-  TODO: this can probably be combined into one section that just loops through 2 items,
-  revist this once getting an idea of data structure
-*/
-
 const markdownText = `## Course Outline
 
 This course is designed to cover a broad spectrum of topics on MongoDB and non-relational databases geared towards learners from beginner to advanced levels. The course includes lessons on comparing and contrasting relational and non-relational databases, outlining the architecture of MongoDB, and detailing how to model data in a document-oriented database. 

--- a/src/components/course-body/styles.ts
+++ b/src/components/course-body/styles.ts
@@ -4,23 +4,7 @@ const CourseBodyWrapper: ThemeUICSSObject = {
   gridColumn: ['span 12', null, null, 'span 7'],
 };
 
-const CourseBodySection: ThemeUICSSObject = {
-  marginBottom: 'inc60',
-};
-
-const CourseBodyTitles: ThemeUICSSObject = {
-  marginBottom: 'inc30',
-};
-
-const CourseBodyText: ThemeUICSSObject = {
-  fontSize: 'inc30',
-  marginBottom: 'inc60',
-};
-
 const styles = {
-  CourseBodyText,
-  CourseBodyTitles,
-  CourseBodySection,
   CourseBodyWrapper,
 };
 

--- a/src/components/markdown/component-mappings/a/index.tsx
+++ b/src/components/markdown/component-mappings/a/index.tsx
@@ -1,0 +1,10 @@
+interface AProps {
+  href: string;
+  children: JSX.Element;
+}
+
+const A = ({ href, children }: AProps): JSX.Element => (
+  <a href={href}>{children}</a>
+);
+
+export default A;

--- a/src/components/markdown/component-mappings/h2/index.tsx
+++ b/src/components/markdown/component-mappings/h2/index.tsx
@@ -1,0 +1,7 @@
+import styles from './styles';
+
+const H2 = ({ children }: { children: JSX.Element }) => (
+  <h2 sx={styles.CourseBodyTitles}>{children}</h2>
+);
+
+export default H2;

--- a/src/components/markdown/component-mappings/h2/styles.ts
+++ b/src/components/markdown/component-mappings/h2/styles.ts
@@ -1,0 +1,9 @@
+import { ThemeUICSSObject } from 'theme-ui';
+
+const CourseBodyTitles: ThemeUICSSObject = {
+  marginBottom: 'inc30',
+};
+
+const styles = { CourseBodyTitles };
+
+export default styles;

--- a/src/components/markdown/component-mappings/index.ts
+++ b/src/components/markdown/component-mappings/index.ts
@@ -1,0 +1,14 @@
+import P from './p';
+import H2 from './h2';
+import A from './a';
+import Youtube from './youtube';
+import { Components } from 'react-markdown';
+
+const componentMappings = {
+  p: P,
+  a: A,
+  h2: H2,
+  youtube: Youtube,
+} as Components;
+
+export default componentMappings;

--- a/src/components/markdown/component-mappings/p/index.tsx
+++ b/src/components/markdown/component-mappings/p/index.tsx
@@ -1,0 +1,7 @@
+import styles from './styles';
+
+const P = ({ children }: { children: JSX.Element }) => (
+  <p sx={styles.CourseBodyText}>{children}</p>
+);
+
+export default P;

--- a/src/components/markdown/component-mappings/p/styles.ts
+++ b/src/components/markdown/component-mappings/p/styles.ts
@@ -1,0 +1,10 @@
+import { ThemeUICSSObject } from 'theme-ui';
+
+const CourseBodyText: ThemeUICSSObject = {
+  fontSize: 'inc30',
+  marginBottom: 'inc60',
+};
+
+const styles = { CourseBodyText };
+
+export default styles;

--- a/src/components/markdown/component-mappings/youtube/index.tsx
+++ b/src/components/markdown/component-mappings/youtube/index.tsx
@@ -1,0 +1,13 @@
+interface YoutubeProps {
+  id: string;
+  children: JSX.Element;
+}
+
+const Youtube = ({ id, children }: YoutubeProps): JSX.Element => (
+  <div>
+    <div>Youtube Text: {children}</div>
+    <div>Youtube Video ID: {id}</div>
+  </div>
+);
+
+export default Youtube;

--- a/src/components/markdown/index.ts
+++ b/src/components/markdown/index.ts
@@ -1,0 +1,3 @@
+import Markdown from './markdown';
+
+export default Markdown;

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -1,0 +1,19 @@
+import ReactMarkdown from 'react-markdown';
+import remarkDirective from 'remark-directive';
+import { customDirective } from './utils';
+import componentMappings from './component-mappings';
+
+interface MarkdownProps {
+  text: string;
+}
+
+const Markdown = ({ text }: MarkdownProps) => (
+  <ReactMarkdown
+    remarkPlugins={[remarkDirective, customDirective]}
+    components={componentMappings}
+  >
+    {text}
+  </ReactMarkdown>
+);
+
+export default Markdown;

--- a/src/components/markdown/utils.ts
+++ b/src/components/markdown/utils.ts
@@ -1,0 +1,18 @@
+import { visit } from 'unist-util-visit';
+
+export const customDirective = () => {
+  return (tree: any) => {
+    visit(
+      tree,
+      ['textDirective', 'leafDirective', 'containerDirective'],
+      node => {
+        node.data = {
+          hName: node.name,
+          hProperties: node.attributes,
+          ...node.data,
+        };
+        return node;
+      }
+    );
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1104,6 +1104,13 @@
   dependencies:
     "@types/tern" "*"
 
+"@types/debug@^4.0.0":
+  version "4.1.7"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
+  integrity sha1-fMDqdhUJEkcJuLLRCQ2PbBeq24I=
+  dependencies:
+    "@types/ms" "*"
+
 "@types/estree@*":
   version "0.0.52"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/estree/-/estree-0.0.52.tgz#7f1f57ad5b741f3d5b210d3b1f145640d89bf8fe"
@@ -1115,6 +1122,13 @@
   integrity sha1-If+6DZjaQ1DbZIkfkqnl2zzbThU=
   dependencies:
     "@types/node" "*"
+
+"@types/hast@^2.0.0":
+  version "2.3.4"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/hast/-/hast-2.3.4.tgz#8aa5ef92c117d20d974a82bdfb6a648b08c0bafc"
+  integrity sha1-iqXvksEX0g2XSoK9+2pkiwjAuvw=
+  dependencies:
+    "@types/unist" "*"
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
@@ -1157,6 +1171,23 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/mdast@^3.0.0":
+  version "3.0.10"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/mdast/-/mdast-3.0.10.tgz#4724244a82a4598884cbbe9bcfd73dff927ee8af"
+  integrity sha1-RyQkSoKkWYiEy76bz9c9/5J+6K8=
+  dependencies:
+    "@types/unist" "*"
+
+"@types/mdurl@^1.0.0":
+  version "1.0.2"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/mdurl/-/mdurl-1.0.2.tgz#e2ce9d83a613bacf284c7be7d491945e39e1f8e9"
+  integrity sha1-4s6dg6YTus8oTHvn1JGUXjnh+Ok=
+
+"@types/ms@*":
+  version "0.7.31"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha1-MbfKZAcSij0rvCf+LSGzRTl/YZc=
+
 "@types/node@*", "@types/node@18.0.3":
   version "18.0.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.3.tgz#463fc47f13ec0688a33aec75d078a0541a447199"
@@ -1182,7 +1213,7 @@
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/prettier/-/prettier-2.6.3.tgz#68ada76827b0010d0db071f739314fa429943d0a"
   integrity sha1-aK2naCewAQ0NsHH3OTFPpCmUPQo=
 
-"@types/prop-types@*":
+"@types/prop-types@*", "@types/prop-types@^15.0.0":
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
@@ -1238,6 +1269,11 @@
   version "4.0.2"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
   integrity sha1-Yoa0xyKNWKt4ZtGXFvNpbgOgk5c=
+
+"@types/unist@*", "@types/unist@^2.0.0":
+  version "2.0.6"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
+  integrity sha1-JQp7FsO5H2cqJFUuxkZ47rHToI0=
 
 "@types/yargs-parser@*":
   version "21.0.0"
@@ -1588,6 +1624,11 @@ babel-preset-jest@^28.1.1:
     babel-plugin-jest-hoist "^28.1.1"
     babel-preset-current-node-syntax "^1.0.0"
 
+bail@^2.0.0:
+  version "2.0.2"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/bail/-/bail-2.0.2.tgz#d26f5cd8fe5d6f832a31517b9f7c356040ba6d5d"
+  integrity sha1-0m9c2P5db4MqMVF7n3w1YEC6bV0=
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -1692,6 +1733,26 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha1-10Q1giYhf5ge1Y9Hmx1rzClUXc8=
+
+character-entities-html4@^2.0.0:
+  version "2.1.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/character-entities-html4/-/character-entities-html4-2.1.0.tgz#1f1adb940c971a4b22ba39ddca6b618dc6e56b2b"
+  integrity sha1-HxrblAyXGksiujndymthjcblays=
+
+character-entities-legacy@^3.0.0:
+  version "3.0.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz#76bc83a90738901d7bc223a9e93759fdd560125b"
+  integrity sha1-dryDqQc4kB17wiOp6TdZ/dVgEls=
+
+character-entities@^2.0.0:
+  version "2.0.2"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/character-entities/-/character-entities-2.0.2.tgz#2d09c2e72cd9523076ccb21157dff66ad43fcc22"
+  integrity sha1-LQnC5yzZUjB2zLIRV9/2atQ/zCI=
+
+character-reference-invalid@^2.0.0:
+  version "2.0.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz#85c66b041e43b47210faf401278abf808ac45cb9"
+  integrity sha1-hcZrBB5DtHIQ+vQBJ4q/gIrEXLk=
 
 charenc@0.0.2:
   version "0.0.2"
@@ -1799,6 +1860,11 @@ combined-stream@^1.0.8:
   integrity sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=
   dependencies:
     delayed-stream "~1.0.0"
+
+comma-separated-tokens@^2.0.0:
+  version "2.0.2"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/comma-separated-tokens/-/comma-separated-tokens-2.0.2.tgz#d4c25abb679b7751c880be623c1179780fe1dd98"
+  integrity sha1-1MJau2ebd1HIgL5iPBF5eA/h3Zg=
 
 commander@^7.2.0:
   version "7.2.0"
@@ -1913,7 +1979,7 @@ data-urls@^3.0.1:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
+debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -1938,6 +2004,13 @@ decimal.js@^10.3.1:
   version "10.3.1"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783"
   integrity sha1-2MOkRKnGd0umDKatcmHDqU/V54M=
+
+decode-named-character-reference@^1.0.0:
+  version "1.0.2"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz#daabac9690874c394c81e4162a0304b35d824f0e"
+  integrity sha1-2quslpCHTDlMgeQWKgMEs12CTw4=
+  dependencies:
+    character-entities "^2.0.0"
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -1972,6 +2045,11 @@ delayed-stream@~1.0.0:
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
+dequal@^2.0.0:
+  version "2.0.3"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha1-JkQhTxmX057Q7g7OcjNUkKesZ74=
+
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
@@ -1981,6 +2059,11 @@ diff-sequences@^28.1.1:
   version "28.1.1"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/diff-sequences/-/diff-sequences-28.1.1.tgz#9989dc731266dc2903457a70e996f3a041913ac6"
   integrity sha1-mYnccxJm3CkDRXpw6ZbzoEGROsY=
+
+diff@^5.0.0:
+  version "5.1.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
+  integrity sha1-vFLSmMXqjfkZSAAiREXtQ//IfkA=
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -2376,6 +2459,11 @@ expect@^28.1.1:
     jest-message-util "^28.1.1"
     jest-util "^28.1.1"
 
+extend@^3.0.0:
+  version "3.0.2"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -2677,6 +2765,11 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hast-util-whitespace@^2.0.0:
+  version "2.0.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/hast-util-whitespace/-/hast-util-whitespace-2.0.0.tgz#4fc1086467cc1ef5ba20673cb6b03cec3a970f1c"
+  integrity sha1-T8EIZGfMHvW6IGc8trA87DqXDxw=
+
 hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -2785,6 +2878,11 @@ inherits@2, inherits@^2.0.4:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+inline-style-parser@0.1.1:
+  version "0.1.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
+  integrity sha1-7Io7QpJ06cCh8cT/qUU6f+9yzqE=
+
 internal-slot@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
@@ -2793,6 +2891,19 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+is-alphabetical@^2.0.0:
+  version "2.0.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/is-alphabetical/-/is-alphabetical-2.0.1.tgz#01072053ea7c1036df3c7d19a6daaec7f19e789b"
+  integrity sha1-AQcgU+p8EDbfPH0Zptqux/GeeJs=
+
+is-alphanumerical@^2.0.0:
+  version "2.0.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz#7c03fbe96e3e931113e57f964b0a368cc2dfd875"
+  integrity sha1-fAP76W4+kxET5X+WSwo2jMLf2HU=
+  dependencies:
+    is-alphabetical "^2.0.0"
+    is-decimal "^2.0.0"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -2813,6 +2924,11 @@ is-boolean-object@^1.1.0:
   dependencies:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
+
+is-buffer@^2.0.0:
+  version "2.0.5"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha1-68JS5ADSL/jXf6CYiIIaJKZYwZE=
 
 is-buffer@~1.1.6:
   version "1.1.6"
@@ -2838,6 +2954,11 @@ is-date-object@^1.0.1:
   dependencies:
     has-tostringtag "^1.0.0"
 
+is-decimal@^2.0.0:
+  version "2.0.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/is-decimal/-/is-decimal-2.0.1.tgz#9469d2dc190d0214fd87d78b78caecc0cc14eef7"
+  integrity sha1-lGnS3BkNAhT9h9eLeMrswMwU7vc=
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -2860,6 +2981,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   dependencies:
     is-extglob "^2.1.1"
 
+is-hexadecimal@^2.0.0:
+  version "2.0.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz#86b5bf668fca307498d319dfc03289d781a90027"
+  integrity sha1-hrW/Zo/KMHSY0xnfwDKJ14GpACc=
+
 is-negative-zero@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
@@ -2881,6 +3007,11 @@ is-obj@^1.0.1:
   version "1.0.1"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
+
+is-plain-obj@^4.0.0:
+  version "4.1.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
+  integrity sha1-1lAl7ew2V84DL9fbY8l4g+rtcfA=
 
 is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
@@ -3460,6 +3591,11 @@ kleur@^3.0.3:
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha1-p5yezIbuHOP6YgbRIWxQHxR/wH4=
 
+kleur@^4.0.3:
+  version "4.1.5"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/kleur/-/kleur-4.1.5.tgz#95106101795f7050c6c650f350c683febddb1780"
+  integrity sha1-lRBhAXlfcFDGxlDzUMaD/r3bF4A=
+
 language-subtag-registry@~0.3.2:
   version "0.3.22"
   resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz#2e1500861b2e457eba7e7ae86877cbd08fa1fd1d"
@@ -3588,6 +3724,11 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
+longest-streak@^3.0.0:
+  version "3.0.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/longest-streak/-/longest-streak-3.0.1.tgz#c97315b7afa0e7d9525db9a5a2953651432bdc5d"
+  integrity sha1-yXMVt6+g59lSXbmlopU2UUMr3F0=
+
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -3635,6 +3776,85 @@ md5@^2.2.1:
     crypt "0.0.2"
     is-buffer "~1.1.6"
 
+mdast-util-definitions@^5.0.0:
+  version "5.1.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/mdast-util-definitions/-/mdast-util-definitions-5.1.1.tgz#2c1d684b28e53f84938bb06317944bee8efa79db"
+  integrity sha1-LB1oSyjlP4STi7BjF5RL7o76eds=
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    unist-util-visit "^4.0.0"
+
+mdast-util-directive@^2.0.0:
+  version "2.2.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/mdast-util-directive/-/mdast-util-directive-2.2.1.tgz#823d8e67e2aad04166e31c0a43931d3462be77fe"
+  integrity sha1-gj2OZ+Kq0EFm4xwKQ5MdNGK+d/4=
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    mdast-util-to-markdown "^1.3.0"
+    parse-entities "^4.0.0"
+    stringify-entities "^4.0.0"
+    unist-util-visit-parents "^5.0.0"
+
+mdast-util-from-markdown@^1.0.0:
+  version "1.2.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/mdast-util-from-markdown/-/mdast-util-from-markdown-1.2.0.tgz#84df2924ccc6c995dec1e2368b2b208ad0a76268"
+  integrity sha1-hN8pJMzGyZXeweI2iysgitCnYmg=
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    decode-named-character-reference "^1.0.0"
+    mdast-util-to-string "^3.1.0"
+    micromark "^3.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-decode-string "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    unist-util-stringify-position "^3.0.0"
+    uvu "^0.5.0"
+
+mdast-util-to-hast@^12.1.0:
+  version "12.1.2"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/mdast-util-to-hast/-/mdast-util-to-hast-12.1.2.tgz#5c793b04014746585254c7ce0bc2d117201a5d1d"
+  integrity sha1-XHk7BAFHRlhSVMfOC8LRFyAaXR0=
+  dependencies:
+    "@types/hast" "^2.0.0"
+    "@types/mdast" "^3.0.0"
+    "@types/mdurl" "^1.0.0"
+    mdast-util-definitions "^5.0.0"
+    mdurl "^1.0.0"
+    micromark-util-sanitize-uri "^1.0.0"
+    trim-lines "^3.0.0"
+    unist-builder "^3.0.0"
+    unist-util-generated "^2.0.0"
+    unist-util-position "^4.0.0"
+    unist-util-visit "^4.0.0"
+
+mdast-util-to-markdown@^1.3.0:
+  version "1.3.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/mdast-util-to-markdown/-/mdast-util-to-markdown-1.3.0.tgz#38b6cdc8dc417de642a469c4fc2abdf8c931bd1e"
+  integrity sha1-OLbNyNxBfeZCpGnE/Cq9+MkxvR4=
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    longest-streak "^3.0.0"
+    mdast-util-to-string "^3.0.0"
+    micromark-util-decode-string "^1.0.0"
+    unist-util-visit "^4.0.0"
+    zwitch "^2.0.0"
+
+mdast-util-to-string@^3.0.0, mdast-util-to-string@^3.1.0:
+  version "3.1.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz#56c506d065fbf769515235e577b5a261552d56e9"
+  integrity sha1-VsUG0GX792lRUjXld7WiYVUtVuk=
+
+mdurl@^1.0.0:
+  version "1.0.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -3644,6 +3864,214 @@ merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micromark-core-commonmark@^1.0.1:
+  version "1.0.6"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-core-commonmark/-/micromark-core-commonmark-1.0.6.tgz#edff4c72e5993d93724a3c206970f5a15b0585ad"
+  integrity sha1-7f9McuWZPZNySjwgaXD1oVsFha0=
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    micromark-factory-destination "^1.0.0"
+    micromark-factory-label "^1.0.0"
+    micromark-factory-space "^1.0.0"
+    micromark-factory-title "^1.0.0"
+    micromark-factory-whitespace "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-chunked "^1.0.0"
+    micromark-util-classify-character "^1.0.0"
+    micromark-util-html-tag-name "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-resolve-all "^1.0.0"
+    micromark-util-subtokenize "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.1"
+    uvu "^0.5.0"
+
+micromark-extension-directive@^2.0.0:
+  version "2.1.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-extension-directive/-/micromark-extension-directive-2.1.1.tgz#d2dae9219618fcce06226d0b63b7a2a23fbe23ec"
+  integrity sha1-0trpIZYY/M4GIm0LY7eioj++I+w=
+  dependencies:
+    micromark-factory-space "^1.0.0"
+    micromark-factory-whitespace "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    parse-entities "^4.0.0"
+    uvu "^0.5.0"
+
+micromark-factory-destination@^1.0.0:
+  version "1.0.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-factory-destination/-/micromark-factory-destination-1.0.0.tgz#fef1cb59ad4997c496f887b6977aa3034a5a277e"
+  integrity sha1-/vHLWa1Jl8SW+Ie2l3qjA0paJ34=
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-factory-label@^1.0.0:
+  version "1.0.2"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-factory-label/-/micromark-factory-label-1.0.2.tgz#6be2551fa8d13542fcbbac478258fb7a20047137"
+  integrity sha1-a+JVH6jRNUL8u6xHglj7eiAEcTc=
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
+
+micromark-factory-space@^1.0.0:
+  version "1.0.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-factory-space/-/micromark-factory-space-1.0.0.tgz#cebff49968f2b9616c0fcb239e96685cb9497633"
+  integrity sha1-zr/0mWjyuWFsD8sjnpZoXLlJdjM=
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-factory-title@^1.0.0:
+  version "1.0.2"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-factory-title/-/micromark-factory-title-1.0.2.tgz#7e09287c3748ff1693930f176e1c4a328382494f"
+  integrity sha1-fgkofDdI/xaTkw8XbhxKMoOCSU8=
+  dependencies:
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
+
+micromark-factory-whitespace@^1.0.0:
+  version "1.0.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-factory-whitespace/-/micromark-factory-whitespace-1.0.0.tgz#e991e043ad376c1ba52f4e49858ce0794678621c"
+  integrity sha1-6ZHgQ603bBulL05JhYzgeUZ4Yhw=
+  dependencies:
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-character@^1.0.0:
+  version "1.1.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-util-character/-/micromark-util-character-1.1.0.tgz#d97c54d5742a0d9611a68ca0cd4124331f264d86"
+  integrity sha1-2XxU1XQqDZYRpoygzUEkMx8mTYY=
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-chunked@^1.0.0:
+  version "1.0.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-util-chunked/-/micromark-util-chunked-1.0.0.tgz#5b40d83f3d53b84c4c6bce30ed4257e9a4c79d06"
+  integrity sha1-W0DYPz1TuExMa84w7UJX6aTHnQY=
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-classify-character@^1.0.0:
+  version "1.0.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-util-classify-character/-/micromark-util-classify-character-1.0.0.tgz#cbd7b447cb79ee6997dd274a46fc4eb806460a20"
+  integrity sha1-y9e0R8t57mmX3SdKRvxOuAZGCiA=
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-combine-extensions@^1.0.0:
+  version "1.0.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.0.0.tgz#91418e1e74fb893e3628b8d496085639124ff3d5"
+  integrity sha1-kUGOHnT7iT42KLjUlghWORJP89U=
+  dependencies:
+    micromark-util-chunked "^1.0.0"
+    micromark-util-types "^1.0.0"
+
+micromark-util-decode-numeric-character-reference@^1.0.0:
+  version "1.0.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.0.0.tgz#dcc85f13b5bd93ff8d2868c3dba28039d490b946"
+  integrity sha1-3MhfE7W9k/+NKGjD26KAOdSQuUY=
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-decode-string@^1.0.0:
+  version "1.0.2"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz#942252ab7a76dec2dbf089cc32505ee2bc3acf02"
+  integrity sha1-lCJSq3p23sLb8InMMlBe4rw6zwI=
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-encode@^1.0.0:
+  version "1.0.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-util-encode/-/micromark-util-encode-1.0.1.tgz#2c1c22d3800870ad770ece5686ebca5920353383"
+  integrity sha1-LBwi04AIcK13Ds5WhuvKWSA1M4M=
+
+micromark-util-html-tag-name@^1.0.0:
+  version "1.1.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.1.0.tgz#eb227118befd51f48858e879b7a419fc0df20497"
+  integrity sha1-6yJxGL79UfSIWOh5t6QZ/A3yBJc=
+
+micromark-util-normalize-identifier@^1.0.0:
+  version "1.0.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.0.0.tgz#4a3539cb8db954bbec5203952bfe8cedadae7828"
+  integrity sha1-SjU5y425VLvsUgOVK/6M7a2ueCg=
+  dependencies:
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-resolve-all@^1.0.0:
+  version "1.0.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-util-resolve-all/-/micromark-util-resolve-all-1.0.0.tgz#a7c363f49a0162e931960c44f3127ab58f031d88"
+  integrity sha1-p8Nj9JoBYukxlgxE8xJ6tY8DHYg=
+  dependencies:
+    micromark-util-types "^1.0.0"
+
+micromark-util-sanitize-uri@^1.0.0:
+  version "1.0.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.0.0.tgz#27dc875397cd15102274c6c6da5585d34d4f12b2"
+  integrity sha1-J9yHU5fNFRAidMbG2lWF001PErI=
+  dependencies:
+    micromark-util-character "^1.0.0"
+    micromark-util-encode "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+
+micromark-util-subtokenize@^1.0.0:
+  version "1.0.2"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-util-subtokenize/-/micromark-util-subtokenize-1.0.2.tgz#ff6f1af6ac836f8bfdbf9b02f40431760ad89105"
+  integrity sha1-/28a9qyDb4v9v5sC9AQxdgrYkQU=
+  dependencies:
+    micromark-util-chunked "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.0"
+    uvu "^0.5.0"
+
+micromark-util-symbol@^1.0.0:
+  version "1.0.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz#b90344db62042ce454f351cf0bebcc0a6da4920e"
+  integrity sha1-uQNE22IELORU81HPC+vMCm2kkg4=
+
+micromark-util-types@^1.0.0, micromark-util-types@^1.0.1:
+  version "1.0.2"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark-util-types/-/micromark-util-types-1.0.2.tgz#f4220fdb319205812f99c40f8c87a9be83eded20"
+  integrity sha1-9CIP2zGSBYEvmcQPjIepvoPt7SA=
+
+micromark@^3.0.0:
+  version "3.0.10"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/micromark/-/micromark-3.0.10.tgz#1eac156f0399d42736458a14b0ca2d86190b457c"
+  integrity sha1-HqwVbwOZ1Cc2RYoUsMothhkLRXw=
+  dependencies:
+    "@types/debug" "^4.0.0"
+    debug "^4.0.0"
+    decode-named-character-reference "^1.0.0"
+    micromark-core-commonmark "^1.0.1"
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.0.0"
+    micromark-util-chunked "^1.0.0"
+    micromark-util-combine-extensions "^1.0.0"
+    micromark-util-decode-numeric-character-reference "^1.0.0"
+    micromark-util-encode "^1.0.0"
+    micromark-util-normalize-identifier "^1.0.0"
+    micromark-util-resolve-all "^1.0.0"
+    micromark-util-sanitize-uri "^1.0.0"
+    micromark-util-subtokenize "^1.0.0"
+    micromark-util-symbol "^1.0.0"
+    micromark-util-types "^1.0.1"
+    uvu "^0.5.0"
 
 micromatch@^4.0.4:
   version "4.0.5"
@@ -3686,6 +4114,11 @@ minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+
+mri@^1.1.0:
+  version "1.2.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
+  integrity sha1-ZyFID+wqEaSImGERWki2y+fMjws=
 
 ms@2.0.0:
   version "2.0.0"
@@ -3941,6 +4374,20 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-entities@^4.0.0:
+  version "4.0.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/parse-entities/-/parse-entities-4.0.0.tgz#f67c856d4e3fe19b1a445c3fabe78dcdc1053eeb"
+  integrity sha1-9nyFbU4/4ZsaRFw/q+eNzcEFPus=
+  dependencies:
+    "@types/unist" "^2.0.0"
+    character-entities "^2.0.0"
+    character-entities-legacy "^3.0.0"
+    character-reference-invalid "^2.0.0"
+    decode-named-character-reference "^1.0.0"
+    is-alphanumerical "^2.0.0"
+    is-decimal "^2.0.0"
+    is-hexadecimal "^2.0.0"
+
 parse-json@^5.0.0, parse-json@^5.2.0:
   version "5.2.0"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
@@ -4073,7 +4520,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -4081,6 +4528,11 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+property-information@^6.0.0:
+  version "6.1.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/property-information/-/property-information-6.1.1.tgz#5ca85510a3019726cb9afed4197b7b8ac5926a22"
+  integrity sha1-XKhVEKMBlybLmv7UGXt7isWSaiI=
 
 psl@^1.1.33:
   version "1.9.0"
@@ -4120,6 +4572,27 @@ react-is@^18.0.0:
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha1-GZQx7qqi4J+GQn77tPFHPttHYJs=
 
+react-markdown@8.0.3:
+  version "8.0.3"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/react-markdown/-/react-markdown-8.0.3.tgz#e8aba0d2f5a1b2124d476ee1fff9448a2f57e4b3"
+  integrity sha1-6Kug0vWhshJNR27h//lEii9X5LM=
+  dependencies:
+    "@types/hast" "^2.0.0"
+    "@types/prop-types" "^15.0.0"
+    "@types/unist" "^2.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-whitespace "^2.0.0"
+    prop-types "^15.0.0"
+    property-information "^6.0.0"
+    react-is "^18.0.0"
+    remark-parse "^10.0.0"
+    remark-rehype "^10.0.0"
+    space-separated-tokens "^2.0.0"
+    style-to-object "^0.3.0"
+    unified "^10.0.0"
+    unist-util-visit "^4.0.0"
+    vfile "^5.0.0"
+
 react@18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
@@ -4153,6 +4626,35 @@ regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
+
+remark-directive@2.0.1:
+  version "2.0.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/remark-directive/-/remark-directive-2.0.1.tgz#1c32d9df8d839a75ba3478112d21fe883635b48e"
+  integrity sha1-HDLZ342DmnW6NHgRLSH+iDY1tI4=
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-directive "^2.0.0"
+    micromark-extension-directive "^2.0.0"
+    unified "^10.0.0"
+
+remark-parse@^10.0.0:
+  version "10.0.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/remark-parse/-/remark-parse-10.0.1.tgz#6f60ae53edbf0cf38ea223fe643db64d112e0775"
+  integrity sha1-b2CuU+2/DPOOoiP+ZD22TREuB3U=
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-from-markdown "^1.0.0"
+    unified "^10.0.0"
+
+remark-rehype@^10.0.0:
+  version "10.1.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/remark-rehype/-/remark-rehype-10.1.0.tgz#32dc99d2034c27ecaf2e0150d22a6dcccd9a6279"
+  integrity sha1-MtyZ0gNMJ+yvLgFQ0iptzM2aYnk=
+  dependencies:
+    "@types/hast" "^2.0.0"
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-hast "^12.1.0"
+    unified "^10.0.0"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -4237,6 +4739,13 @@ rxjs@^7.5.1:
   integrity sha1-BEZXdVeGKv1pA1F858rnnsuWYrw=
   dependencies:
     tslib "^2.1.0"
+
+sade@^1.7.3:
+  version "1.8.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/sade/-/sade-1.8.1.tgz#0a78e81d658d394887be57d2a409bf703a3b2701"
+  integrity sha1-CnjoHWWNOUiHvlfSpAm/cDo7JwE=
+  dependencies:
+    mri "^1.1.0"
 
 safe-buffer@~5.1.1:
   version "5.1.2"
@@ -4369,6 +4878,11 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha1-dHIq8y6WFOnCh6jQu95IteLxomM=
 
+space-separated-tokens@^2.0.0:
+  version "2.0.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/space-separated-tokens/-/space-separated-tokens-2.0.1.tgz#43193cec4fb858a2ce934b7f98b7f2c18107098b"
+  integrity sha1-Qxk87E+4WKLOk0t/mLfywYEHCYs=
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -4435,6 +4949,14 @@ string.prototype.trimstart@^1.0.5:
     define-properties "^1.1.4"
     es-abstract "^1.19.5"
 
+stringify-entities@^4.0.0:
+  version "4.0.3"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/stringify-entities/-/stringify-entities-4.0.3.tgz#cfabd7039d22ad30f3cc435b0ca2c1574fc88ef8"
+  integrity sha1-z6vXA50irTDzzENbDKLBV0/Ijvg=
+  dependencies:
+    character-entities-html4 "^2.0.0"
+    character-entities-legacy "^3.0.0"
+
 stringify-object@^3.3.0:
   version "3.3.0"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
@@ -4477,6 +4999,13 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+style-to-object@^0.3.0:
+  version "0.3.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/style-to-object/-/style-to-object-0.3.0.tgz#b1b790d205991cc783801967214979ee19a76e46"
+  integrity sha1-sbeQ0gWZHMeDgBlnIUl57hmnbkY=
+  dependencies:
+    inline-style-parser "0.1.1"
 
 styled-jsx@5.0.2:
   version "5.0.2"
@@ -4628,6 +5157,16 @@ tr46@~0.0.3:
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
+trim-lines@^3.0.0:
+  version "3.0.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
+  integrity sha1-2ALjMqB9+GHEiALAQyEBexvYczg=
+
+trough@^2.0.0:
+  version "2.1.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/trough/-/trough-2.1.0.tgz#0f7b511a4fde65a46f18477ab38849b22c554876"
+  integrity sha1-D3tRGk/eZaRvGEd6s4hJsixVSHY=
+
 tsconfig-paths@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
@@ -4704,6 +5243,67 @@ unbox-primitive@^1.0.2:
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
+unified@^10.0.0:
+  version "10.1.2"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/unified/-/unified-10.1.2.tgz#b1d64e55dafe1f0b98bb6c719881103ecf6c86df"
+  integrity sha1-sdZOVdr+HwuYu2xxmIEQPs9sht8=
+  dependencies:
+    "@types/unist" "^2.0.0"
+    bail "^2.0.0"
+    extend "^3.0.0"
+    is-buffer "^2.0.0"
+    is-plain-obj "^4.0.0"
+    trough "^2.0.0"
+    vfile "^5.0.0"
+
+unist-builder@^3.0.0:
+  version "3.0.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/unist-builder/-/unist-builder-3.0.0.tgz#728baca4767c0e784e1e64bb44b5a5a753021a04"
+  integrity sha1-couspHZ8DnhOHmS7RLWlp1MCGgQ=
+  dependencies:
+    "@types/unist" "^2.0.0"
+
+unist-util-generated@^2.0.0:
+  version "2.0.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/unist-util-generated/-/unist-util-generated-2.0.0.tgz#86fafb77eb6ce9bfa6b663c3f5ad4f8e56a60113"
+  integrity sha1-hvr7d+ts6b+mtmPD9a1PjlamARM=
+
+unist-util-is@^5.0.0:
+  version "5.1.1"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/unist-util-is/-/unist-util-is-5.1.1.tgz#e8aece0b102fa9bc097b0fef8f870c496d4a6236"
+  integrity sha1-6K7OCxAvqbwJew/vj4cMSW1KYjY=
+
+unist-util-position@^4.0.0:
+  version "4.0.3"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/unist-util-position/-/unist-util-position-4.0.3.tgz#5290547b014f6222dff95c48d5c3c13a88fadd07"
+  integrity sha1-UpBUewFPYiLf+VxI1cPBOoj63Qc=
+  dependencies:
+    "@types/unist" "^2.0.0"
+
+unist-util-stringify-position@^3.0.0:
+  version "3.0.2"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz#5c6aa07c90b1deffd9153be170dce628a869a447"
+  integrity sha1-XGqgfJCx3v/ZFTvhcNzmKKhppEc=
+  dependencies:
+    "@types/unist" "^2.0.0"
+
+unist-util-visit-parents@^5.0.0:
+  version "5.1.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/unist-util-visit-parents/-/unist-util-visit-parents-5.1.0.tgz#44bbc5d25f2411e7dfc5cecff12de43296aa8521"
+  integrity sha1-RLvF0l8kEeffxc7P8S3kMpaqhSE=
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+
+unist-util-visit@^4.0.0:
+  version "4.1.0"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/unist-util-visit/-/unist-util-visit-4.1.0.tgz#f41e407a9e94da31594e6b1c9811c51ab0b3d8f5"
+  integrity sha1-9B5Aep6U2jFZTmscmBHFGrCz2PU=
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+    unist-util-visit-parents "^5.0.0"
+
 universalify@^0.1.2:
   version "0.1.2"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
@@ -4729,6 +5329,16 @@ use-sync-external-store@1.1.0:
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz#3343c3fe7f7e404db70f8c687adf5c1652d34e82"
   integrity sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==
 
+uvu@^0.5.0:
+  version "0.5.6"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/uvu/-/uvu-0.5.6.tgz#2754ca20bcb0bb59b64e9985e84d2e81058502df"
+  integrity sha1-J1TKILywu1m2TpmF6E0ugQWFAt8=
+  dependencies:
+    dequal "^2.0.0"
+    diff "^5.0.0"
+    kleur "^4.0.3"
+    sade "^1.7.3"
+
 v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
@@ -4742,6 +5352,24 @@ v8-to-istanbul@^9.0.1:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
+
+vfile-message@^3.0.0:
+  version "3.1.2"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/vfile-message/-/vfile-message-3.1.2.tgz#a2908f64d9e557315ec9d7ea3a910f658ac05f7d"
+  integrity sha1-opCPZNnlVzFeydfqOpEPZYrAX30=
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-stringify-position "^3.0.0"
+
+vfile@^5.0.0:
+  version "5.3.4"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/vfile/-/vfile-5.3.4.tgz#bbb8c96b956693bbf70b2c67fdb5781dff769b93"
+  integrity sha1-u7jJa5Vmk7v3Cyxn/bV4Hf92m5M=
+  dependencies:
+    "@types/unist" "^2.0.0"
+    is-buffer "^2.0.0"
+    unist-util-stringify-position "^3.0.0"
+    vfile-message "^3.0.0"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"
@@ -4921,3 +5549,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=
+
+zwitch@^2.0.0:
+  version "2.0.2"
+  resolved "http://artifactory.corp.mongodb.com/artifactory/api/npm/npm/zwitch/-/zwitch-2.0.2.tgz#91f8d0e901ffa3d66599756dde7f57b17c95dce1"
+  integrity sha1-kfjQ6QH/o9ZlmXVt3n9XsXyV3OE=


### PR DESCRIPTION
[DEVHUB-1411](https://jira.mongodb.org/browse/DEVHUB-1411)

The main part of this is adding `react-markdown` to parse markdown to React components, and `remark-directive` which allows us to map custom markdown directives (in this case `::youtube`) to custom components.

I've set up a new `Markdown` component, which will handle all of this. Within the `components/markdown` directory, along with this component is a directory `component-mappings`. This directory contains custom components that we use for markdown. I've filled out the logic for `p` and `h2`, but will leave the more complex implementation of `youtube` and `a` to @justinmckenzie. Any changes should be able to be contained to just these components, but if something is wrong, just let me know.