### PR TITLE
[DEVHUB-1424] Add On-Demand Revalidation

### DIFF
--- a/src/lib/cms-content.ts
+++ b/src/lib/cms-content.ts
@@ -37,7 +37,7 @@ const itemMap = ({
   return {
     id,
     title,
-    contentType,
+    contentType: contentType === 'CaseStudy' ? 'Case Study' : contentType,
     slug,
     shortDescription,
     longDescription,

--- a/src/pages/api/revalidate.ts
+++ b/src/pages/api/revalidate.ts
@@ -7,7 +7,7 @@ const limiter = rateLimit({
   ttl: 60 * 1000,
 });
 
-const reavlidateHandler = async (req: NextApiRequest, res: NextApiResponse) => {
+const revalidateHandler = async (req: NextApiRequest, res: NextApiResponse) => {
   const token = process.env.REVALIDATE_TOKEN;
 
   if (!token) {
@@ -27,7 +27,7 @@ const reavlidateHandler = async (req: NextApiRequest, res: NextApiResponse) => {
     const IP = getIP(req);
     await limiter.check(res, MAX_POSTS_PER_PERIOD, IP || '');
   } catch {
-    return res.status(500).json({ error: { message: 'Something went wrong' } });
+    return res.status(429).json({ error: { message: 'Rate limit exceeded' } });
   }
 
   const { slug, contentType } = req.body;
@@ -45,10 +45,11 @@ const reavlidateHandler = async (req: NextApiRequest, res: NextApiResponse) => {
     }
     await res.revalidate(`/academia/courses/${slug}`);
   } catch (err) {
+    console.error(`There was an error revalidating ${slug}`);
     return res.status(500).send('Error revalidating');
   }
 
   return res.json({ revalidated: true });
 };
 
-export default reavlidateHandler;
+export default revalidateHandler;

--- a/src/pages/api/revalidate.ts
+++ b/src/pages/api/revalidate.ts
@@ -30,36 +30,21 @@ const reavlidateHandler = async (req: NextApiRequest, res: NextApiResponse) => {
     return res.status(500).json({ error: { message: 'Something went wrong' } });
   }
 
-  const { model, entry } = req.body;
+  const { slug, contentType } = req.body;
 
-  if (!model || !entry) {
+  if (!slug || !contentType) {
     return res
       .status(400)
-      .send('"model" and "entry" must be defined on the body');
-  }
-
-  if (model !== 'academia') {
-    console.log(
-      `Did not revalidate because collection was ${model}, not academia.`
-    );
-    return res.status(200).json({ revalidated: false });
+      .send('"slug" and "contentType" must be defined in the body');
   }
 
   try {
     await res.revalidate('/academia');
-    console.log('Successfully revalidated home page');
-    if (entry.contentType !== 'Course') {
+    if (contentType !== 'Course') {
       return res.json({ revalidated: true });
     }
-    if (!entry.slug) {
-      return res
-        .status(400)
-        .send('"slug" must be defined in the "entry" object to revalidate');
-    }
-    await res.revalidate(`/academia/courses/${entry.slug}`);
-    console.log('Successfully revalidated', entry.slug);
+    await res.revalidate(`/academia/courses/${slug}`);
   } catch (err) {
-    console.log(err);
     return res.status(500).send('Error revalidating');
   }
 

--- a/src/pages/api/revalidate.ts
+++ b/src/pages/api/revalidate.ts
@@ -1,0 +1,69 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import rateLimit, { getIP, MAX_POSTS_PER_PERIOD } from 'lib/rate-limit';
+
+const limiter = rateLimit({
+  max: 5, // cache limit of 5 per 60 second period.
+  ttl: 60 * 1000,
+});
+
+const reavlidateHandler = async (req: NextApiRequest, res: NextApiResponse) => {
+  const token = process.env.REVALIDATE_TOKEN;
+
+  if (!token) {
+    console.error('REVALIDATE_TOKEN is not defined.');
+    return res.status(500).json({ error: { message: 'Something went wrong' } });
+  }
+
+  if (req.headers.authorization !== `Bearer ${token}`) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).send('This is a POST-only endpoint');
+  }
+
+  try {
+    const IP = getIP(req);
+    await limiter.check(res, MAX_POSTS_PER_PERIOD, IP || '');
+  } catch {
+    return res.status(500).json({ error: { message: 'Something went wrong' } });
+  }
+
+  const { model, entry } = req.body;
+
+  if (!model || !entry) {
+    return res
+      .status(400)
+      .send('"model" and "entry" must be defined on the body');
+  }
+
+  if (model !== 'academia') {
+    console.log(
+      `Did not revalidate because collection was ${model}, not academia.`
+    );
+    return res.status(200).json({ revalidated: false });
+  }
+
+  try {
+    await res.revalidate('/academia');
+    console.log('Successfully revalidated home page');
+    if (entry.contentType !== 'Course') {
+      return res.json({ revalidated: true });
+    }
+    if (!entry.slug) {
+      return res
+        .status(400)
+        .send('"slug" must be defined in the "entry" object to revalidate');
+    }
+    await res.revalidate(`/academia/courses/${entry.slug}`);
+    console.log('Successfully revalidated', entry.slug);
+  } catch (err) {
+    console.log(err);
+    return res.status(500).send('Error revalidating');
+  }
+
+  return res.json({ revalidated: true });
+};
+
+export default reavlidateHandler;

--- a/src/pages/courses/[course].tsx
+++ b/src/pages/courses/[course].tsx
@@ -24,7 +24,7 @@ export default function CoursePage({ openForm, content }: CoursePageProps) {
       <main sx={styles.CoursePageMain}>
         {/* @ts-ignore */}
         <GridLayout sx={styles.CoursePageGrid}>
-          <CourseBody />
+          <CourseBody wrapperStyles={styles.CoursePageBody} />
           <CourseAside
             openForm={openForm}
             level={courseData.level}

--- a/src/pages/courses/[course].tsx
+++ b/src/pages/courses/[course].tsx
@@ -47,7 +47,6 @@ export const getStaticPaths: GetStaticPaths = async () => {
   const paths = content
     .filter(({ contentType }) => contentType === 'Course')
     .map(({ slug }) => ({ params: { course: slug } }));
-  console.log('Getting paths:', paths);
 
   return {
     paths,
@@ -60,11 +59,11 @@ export const getStaticProps: GetStaticProps<PageProps> = async ({ params }) => {
     throw Error('No course slug passed to getStaticProps');
   }
   const { course } = params;
+
   let content;
   try {
     content = await getContentBySlug(course as string);
   } catch (err) {
-    console.log(`Getting props, but no slug for ${course}`);
     // Force a 404 on a slug that doesn't exist.
     return {
       notFound: true,
@@ -72,15 +71,12 @@ export const getStaticProps: GetStaticProps<PageProps> = async ({ params }) => {
   }
 
   if (content.contentType !== 'Course') {
-    console.log(
-      `Getting props, but ${course} is a ${content.contentType}, not a Course`
-    );
     // Force a 404 on non-course fallback route.
     return {
       notFound: true,
     };
   }
-  console.log('Got props for', content.title);
+
   return {
     props: { content },
   };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -63,6 +63,10 @@ export default function Home({
 
 export const getStaticProps: GetStaticProps<PageProps> = async () => {
   const content = await getAllContent();
+  console.log(
+    'Getting all content for home page:',
+    content.map(({ title }) => title)
+  );
 
   return {
     props: { content },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -73,7 +73,6 @@ export const getStaticProps: GetStaticProps<{
     lectures: [],
     resources: [],
   };
-  console.log('Getting all content for home page:');
 
   (await getAllContent()).forEach(item =>
     item.contentType === 'Course'


### PR DESCRIPTION
[DEVHUB-1424](https://jira.mongodb.org/browse/DEVHUB-1424)

https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration#on-demand-revalidation

In conjunction with https://github.com/10gen/devhub-cms/pull/146, when a content piece is updated in the CMS, a POST will be sent to `/academia/api/revalidate`, and will rebuild both the home page, and that content piece's corresponding page (if it is a course).