### PR TITLE
[CHORE]: UX Fixes

### DIFF
--- a/src/components/card/styles.ts
+++ b/src/components/card/styles.ts
@@ -18,6 +18,9 @@ const CardWrapper: ThemeUICSSObject = {
 
 const CardContent: ThemeUICSSObject = {
   flex: '1 1 auto',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
 };
 
 const CardPill: ThemeUICSSObject = {
@@ -30,8 +33,8 @@ const CardTitle: ThemeUICSSObject = {
 };
 
 const CardLessonCount: ThemeUICSSObject = {
-  display: 'block',
-  marginTop: 'inc10',
+  marginTop: 'auto',
+  paddingTop: 'inc10',
 };
 
 const CardDivider: ThemeUICSSObject = {

--- a/src/components/course-list/styles.ts
+++ b/src/components/course-list/styles.ts
@@ -11,6 +11,9 @@ const CourseListWrapper: ThemeUICSSObject = {
   li: {
     marginTop: 'inc30',
   },
+  h3: {
+    display: 'inline-block',
+  },
 };
 
 const CourseListLinks: ThemeUICSSObject = {


### PR DESCRIPTION
- Fix Lesson Materials label not being inline with `<ol>` number on Safari
- Adjust card layout for "Lessons" count to show at bottom of flex container (see screenshots)

<img width="1434" alt="Screen Shot 2022-08-10 at 10 09 42 AM" src="https://user-images.githubusercontent.com/20843509/183922780-986963f6-dd66-4657-8044-4e68a91c18d7.png">

<img width="1456" alt="Screen Shot 2022-08-10 at 10 09 29 AM" src="https://user-images.githubusercontent.com/20843509/183922786-66d1a443-4e00-445d-b163-55ebebe215e0.png">

