### PR TITLE
[CHORE] Revalidate every 2 minutes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ yarn-error.log*
 
 # Sentry
 .sentryclirc
+
+.vscode

--- a/src/pages/courses/[course].tsx
+++ b/src/pages/courses/[course].tsx
@@ -96,5 +96,6 @@ export const getStaticProps: GetStaticProps<PageProps> = async ({ params }) => {
 
   return {
     props: { content },
+    revalidate: 120,
   };
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -82,5 +82,6 @@ export const getStaticProps: GetStaticProps<{
 
   return {
     props: { content },
+    revalidate: 120,
   };
 };


### PR DESCRIPTION
Revalidate every 2 minutes because on-demand revalidation can only affect 1 pod at a time, but we have multiple pods running the app in production. This will allow each pod to pick up any changes they may have missed.