### PR TITLE
[CHORE]: UX Changes for CTA on Featured Card

### DIFF
--- a/src/components/featured-card/featured-card.tsx
+++ b/src/components/featured-card/featured-card.tsx
@@ -1,3 +1,4 @@
+import { ThemeUICSSObject } from 'theme-ui';
 import { Link, Button, TypographyScale } from '@mdb/flora';
 import Image from 'components/image';
 import FeaturedCardProps from './types';
@@ -12,6 +13,18 @@ export default function FeaturedCard({
   fullWidth = false,
   cta,
 }: FeaturedCardProps): JSX.Element {
+  const renderCTA = (ctaStyles: ThemeUICSSObject = {}) =>
+    cta.type === 'button' ? (
+      <Button href={cta.href} target="_blank">
+        {cta.text}
+      </Button>
+    ) : (
+      // @ts-ignore
+      <Link href={cta.href} target="_blank" linkIcon="arrow" sx={ctaStyles}>
+        {cta.text}
+      </Link>
+    );
+
   return (
     <div
       sx={{
@@ -26,7 +39,12 @@ export default function FeaturedCard({
           ...(fullWidth && { ...styles.FeaturedCardContent_FullWidth }),
         }}
       >
-        <div sx={styles.FeaturedCardText}>
+        <div
+          sx={{
+            ...styles.FeaturedCardText,
+            ...(fullWidth && { ...styles.FeaturedCardText_FullWidth }),
+          }}
+        >
           {/* @ts-ignore */}
           <TypographyScale
             variant="heading5"
@@ -48,37 +66,29 @@ export default function FeaturedCard({
           >
             {subtitle}
           </TypographyScale>
+          {fullWidth && renderCTA()}
         </div>
-        {cta.type === 'button' ? (
-          <Button target="_blank" href={cta.href}>
-            {cta.text}
-          </Button>
-        ) : (
-          // @ts-ignore
-          <Link href={cta.href} target="_blank" linkIcon="arrow">
-            {cta.text}
-          </Link>
-        )}
-      </div>
-      <div
-        sx={{
-          ...styles.FeaturedCardImageWrapper,
-          ...(fullWidth && { ...styles.FeaturedCardImageWrapper_FullWidth }),
-        }}
-      >
         <div
           sx={{
-            ...(imgSizes && { ...imgSizes }),
-            ...(fullWidth && { ...styles.FeaturedCardImage_FullWidth }),
+            ...styles.FeaturedCardImageWrapper,
+            ...(fullWidth && { ...styles.FeaturedCardImageWrapper_FullWidth }),
           }}
         >
-          <Image
-            alt="mongoDB icon"
-            src={imgSrc}
-            styles={styles.FeaturedCardImage}
-          />
+          <div
+            sx={{
+              ...(imgSizes && { ...imgSizes }),
+              ...(fullWidth && { ...styles.FeaturedCardImage_FullWidth }),
+            }}
+          >
+            <Image
+              src={imgSrc}
+              alt="mongoDB icon"
+              styles={styles.FeaturedCardImage}
+            />
+          </div>
         </div>
       </div>
+      {!fullWidth && renderCTA(styles.FeaturedCardCTA)}
     </div>
   );
 }

--- a/src/components/featured-card/styles.ts
+++ b/src/components/featured-card/styles.ts
@@ -5,9 +5,7 @@ import theme from '@mdb/flora/theme';
 const FeaturedCardWrapper: ThemeUICSSObject = {
   width: '100%',
   display: 'flex',
-  flexWrap: 'nowrap',
-  flexDirection: ['column', 'row', null, 'column'],
-  alignItems: 'center',
+  flexDirection: 'column',
   paddingTop: ['inc50', 'inc70', null, 'inc80'],
   paddingBottom: ['inc70', null, null, 'inc80'],
   paddingLeft: ['inc70', null, null, 'inc100'],
@@ -26,18 +24,16 @@ const FeaturedCardWrapper: ThemeUICSSObject = {
 
 const FeaturedCardContent: ThemeUICSSObject = {
   height: '100%',
-  width: [null, '50%', null, '100%'],
-  order: [2, 1, null, 2],
   display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'space-between',
-  alignItems: ['start', null, null, 'center'],
+  flexDirection: ['column', 'row', null, 'column'],
+  alignItems: ['center', null, null, 'center'],
 };
 
 const FeaturedCardText: ThemeUICSSObject = {
   display: 'flex',
   flexDirection: 'column',
-  alignItems: ['start', null, null, 'center'],
+  order: [2, 1, null, 2],
+  width: [null, '50%', null, '100%'],
 };
 
 const FeaturedCardTitle: ThemeUICSSObject = {
@@ -58,7 +54,7 @@ const FeaturedCardImageWrapper: ThemeUICSSObject = {
   width: [null, '50%', null, '100%'],
   display: [null, 'flex'],
   justifyContent: [null, 'center'],
-  marginBottom: ['inc40', 0, null, 'inc40'],
+  marginBottom: ['inc40', '-inc40', '-inc60', 'inc40'],
 };
 
 const FeaturedCardImage: ThemeUICSSObject = {
@@ -66,11 +62,14 @@ const FeaturedCardImage: ThemeUICSSObject = {
   width: '100%',
 };
 
+const FeaturedCardCTA: ThemeUICSSObject = {
+  margin: [null, null, null, '0 auto'],
+};
+
 /* --- fullWidth PROP CARD STYLES --- */
 const FeaturedCardWrapper_FullWidth: ThemeUICSSObject = {
-  flexDirection: ['column', 'row'],
-  paddingTop: '0 !important',
-  paddingBottom: '0 !important',
+  paddingTop: '0',
+  paddingBottom: '0',
   paddingLeft: ['0', null, null, 'inc100'],
   paddingRight: ['0', null, null, 'inc100'],
   marginTop: ['inc80', null, null, 'inc130'],
@@ -79,10 +78,14 @@ const FeaturedCardWrapper_FullWidth: ThemeUICSSObject = {
 };
 
 const FeaturedCardContent_FullWidth: ThemeUICSSObject = {
-  order: [2, 1],
-  alignItems: 'start',
-  marginRight: [null, 'inc20', 0, 0],
+  flexDirection: ['column', 'row'],
+};
+
+const FeaturedCardText_FullWidth: ThemeUICSSObject = {
   width: ['100%', '50%', null, '45%'],
+  marginRight: [null, 'inc20', 0],
+  alignItems: 'start',
+  order: [2, 1],
 };
 
 const FeaturedCardTitle_FullWidth: ThemeUICSSObject = {
@@ -101,13 +104,13 @@ const FeaturedCardSubtitle_FullWidth: ThemeUICSSObject = {
 const FeaturedCardImageWrapper_FullWidth: ThemeUICSSObject = {
   order: [1, 2],
   width: [null, '50%'],
-  marginBottom: ['inc70', 0],
+  marginBottom: ['inc80', 0],
 };
 
 const FeaturedCardImage_FullWidth: ThemeUICSSObject = {
   // negative margins negates whitespace in SVG adding whitespace height
-  marginTop: ['-inc30', '-inc40', null, '-inc70'],
-  marginBottom: ['-inc30', '-inc40', null, '-inc70'],
+  marginTop: ['-inc30', '-inc50', null, '-inc70'],
+  marginBottom: ['-inc30', '-inc50', null, '-inc70'],
   marginRight: [null, null, '-inc40', '-inc100'],
 };
 
@@ -120,6 +123,7 @@ const FeaturedCardWrapper_NoBorder: ThemeUICSSObject = {
 };
 
 const styles = {
+  FeaturedCardCTA,
   FeaturedCardText,
   FeaturedCardImage,
   FeaturedCardTitle,
@@ -127,6 +131,7 @@ const styles = {
   FeaturedCardWrapper,
   FeaturedCardSubtitle,
   FeaturedCardImageWrapper,
+  FeaturedCardText_FullWidth,
   FeaturedCardImage_FullWidth,
   FeaturedCardTitle_FullWidth,
   FeaturedCardWrapper_NoBorder,

--- a/src/components/featured-card/styles.ts
+++ b/src/components/featured-card/styles.ts
@@ -25,8 +25,8 @@ const FeaturedCardWrapper: ThemeUICSSObject = {
 const FeaturedCardContent: ThemeUICSSObject = {
   height: '100%',
   display: 'flex',
+  alignItems: 'center',
   flexDirection: ['column', 'row', null, 'column'],
-  alignItems: ['center', null, null, 'center'],
 };
 
 const FeaturedCardText: ThemeUICSSObject = {


### PR DESCRIPTION
Scope
- adjusts the layout of the CTA on the Featured Card to use card's width to prevent the CTA text spanning 3-4 lines depending on viewport size. See screenshots for comparisons

Before at `485px`:
<img width="224" alt="Screen Shot 2022-08-15 at 11 40 59 AM" src="https://user-images.githubusercontent.com/20843509/184667732-4e008af9-203f-476b-9b50-dd4c6fd2b982.png">

After at `485px`:
<img width="233" alt="Screen Shot 2022-08-15 at 11 40 52 AM" src="https://user-images.githubusercontent.com/20843509/184667806-02a876d1-bf04-409b-8a3d-49fe4ac73003.png">

Before at `685px`:
<img width="322" alt="Screen Shot 2022-08-15 at 11 43 26 AM" src="https://user-images.githubusercontent.com/20843509/184668142-2fe3a4d7-21b2-4ef5-a552-0a00424659f7.png">

After at `685px`:
<img width="478" alt="Screen Shot 2022-08-15 at 11 43 20 AM" src="https://user-images.githubusercontent.com/20843509/184668193-b093de56-bc5c-4e87-8f21-b21eda7a1978.png">
