### PR TITLE
[BUG] Convert undefined to string on empty Course Syllabus field

### DIFF
--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -132,6 +132,8 @@ export default function Form({
 
     const body = form as unknown as Registration; // converts required formValues arg type to required Registration type for POST
 
+    body.courseSyllabus = body.courseSyllabus || ''; // unrequired textarea value can be undefined. If so we convert it to a blank string.
+
     try {
       await axios.post('/academia/api/registration', body);
       setFormSuccess(true);


### PR DESCRIPTION
When this field was left empty and a user tried to submit the form, they would get an error from the server because courseSyllabus was undefined. This sets it to a blank string as an empty state.