### PR TITLE
[FIX] Only run GA script eval on the server

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import Head from 'next/head';
-import Script from 'next/script';
 import theme from '@mdb/flora/theme';
 import { ThemeProvider } from '@theme-ui/core';
 
@@ -47,23 +46,6 @@ export default function EducatorPortal({ Component, pageProps }: AppProps) {
         />
         <meta property="twitter:site" content="@MongoDB" />
       </Head>
-      {/* Google Tag Manager - Global base code */}
-      <Script
-        id="ga-base"
-        strategy="afterInteractive"
-        dangerouslySetInnerHTML={{
-          __html: `
-                  !function(e,n){var t=document.createElement("script"),o=null,x="pathway";t.async=!0,t.src='https://'+x+'.mongodb.com/'+(e?x+'-debug.js':''),
-                  document.head.append(t),t.addEventListener("load",function(){o=window.pathway.default,(n&&o.configure(n)),o.createProfile("mongodbcom").load(),
-                  window.segment=o})}${
-                    process.env['APP_ENV'] === 'production'
-                      ? '()'
-                      : '(!0,{debugMode:!0})'
-                  };
-                `,
-        }}
-        async
-      />
       <ThemeProvider theme={theme}>
         <Layout isFormOpen={isFormOpen}>
           <Form isOpen={isFormOpen} closeForm={() => setIsFormOpen(false)} />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,4 +1,8 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
+import Script from 'next/script';
+
+const gaScriptArgs =
+  process.env['APP_ENV'] === 'production' ? '' : '!0,{debugMode:!0}';
 
 export default class MyDocument extends Document {
   render() {
@@ -8,6 +12,18 @@ export default class MyDocument extends Document {
           <link
             rel="dns-prefetch preconnect"
             href="https://www.google-analytics.com"
+          />
+          <Script
+            id="ga-base"
+            strategy="afterInteractive"
+            dangerouslySetInnerHTML={{
+              __html: `
+                  !function(e,n){var t=document.createElement("script"),o=null,x="pathway";t.async=!0,t.src='https://'+x+'.mongodb.com/'+(e?x+'-debug.js':''),
+                  document.head.append(t),t.addEventListener("load",function(){o=window.pathway.default,(n&&o.configure(n)),o.createProfile("mongodbcom").load(),
+                  window.segment=o})}(${gaScriptArgs});
+                `,
+            }}
+            async
           />
         </Head>
         <body>


### PR DESCRIPTION
_document only runs on the server, whereas _app runs on the client as well, so I am now running the script evaluation on the server so we can actually tell what environment we're in.